### PR TITLE
Add OpenPaths provider

### DIFF
--- a/apps/studio/src/client/components/ai-provider-icon.tsx
+++ b/apps/studio/src/client/components/ai-provider-icon.tsx
@@ -60,6 +60,7 @@ const PROVIDER_ICON_MAP: Record<
   ollama: SiOllama,
   openai: SiOpenai,
   "openai-compatible": GrNodes,
+  openpaths: GrNodes,
   openrouter: OpenRouter,
   perplexity: Perplexity,
   quests: QuestsLogoSimpleIcon,

--- a/cspell.json
+++ b/cspell.json
@@ -61,6 +61,7 @@
     "ollama",
     "oneline",
     "opencode",
+    "openpaths",
     "openrouter",
     "orpc",
     "overscan",

--- a/packages/ai-gateway/src/lib/add-heuristic-tags.ts
+++ b/packages/ai-gateway/src/lib/add-heuristic-tags.ts
@@ -26,6 +26,7 @@ const DEFAULT_MODELS_BY_CONFIG_TYPE: Partial<
   google: ["gemini-3-pro", "gemini-3-pro-preview"],
   groq: ["gpt-oss-120b"],
   openai: ["gpt-5.1-codex-mini"],
+  openpaths: ["openpaths/auto"],
   "x-ai": ["grok-code-fast-1"],
   "z-ai": ["glm-4.6"],
 };

--- a/packages/ai-gateway/src/lib/providers/metadata.ts
+++ b/packages/ai-gateway/src/lib/providers/metadata.ts
@@ -225,6 +225,17 @@ const PROVIDER_METADATA = {
     type: "openai-compatible",
     url: "",
   },
+  openpaths: {
+    api: {
+      defaultBaseURL: "https://openpaths.io/v1",
+      keyURL: addRef("https://openpaths.io/account"),
+    },
+    description: "Access an extensive catalog of models across providers",
+    name: "OpenPaths",
+    tags: ["recommended"],
+    type: "openpaths",
+    url: "https://openpaths.io",
+  },
   openrouter: {
     api: {
       defaultBaseURL: "https://openrouter.ai/api",

--- a/packages/shared/src/schemas/ai-gateway.ts
+++ b/packages/shared/src/schemas/ai-gateway.ts
@@ -20,6 +20,7 @@ export const AIProviderTypeSchema = z.enum([
   "ollama",
   "openai-compatible",
   "openai",
+  "openpaths",
   "openrouter",
   "perplexity",
   "quests",


### PR DESCRIPTION
## What

Adds [OpenPaths](https://openpaths.io) as a selectable AI provider. OpenPaths is an OpenAI-compatible model gateway (base URL `https://openpaths.io/v1`), so it is wired in entirely through the existing `openai-compatible` code paths — no provider-specific SDK or headers.

## Changes

- `packages/shared/src/schemas/ai-gateway.ts`: add `"openpaths"` to `AIProviderTypeSchema`.
- `packages/ai-gateway/src/lib/providers/metadata.ts`: add the `openpaths` provider metadata block (default base URL `https://openpaths.io/v1`, key page `https://openpaths.io/account`, `recommended` tag).
- `packages/ai-gateway/src/lib/add-heuristic-tags.ts`: register `openpaths/auto` as the default model for the provider.
- `apps/studio/src/client/components/ai-provider-icon.tsx`: map an icon for the provider (generic nodes icon, matching the custom OpenAI-compatible provider).
- `cspell.json`: add `openpaths` to the dictionary.

The AI SDK mapping, model fetching (`GET /v1/models`), and API key verification all flow through the existing `@ai-sdk/openai-compatible` fallbacks, so no additional switch arms were required.

## Testing

- `pnpm --filter @quests/shared check:types` — pass
- `pnpm --filter @quests/ai-gateway check:types` — pass
- `pnpm --filter @quests/studio check:types` — pass
- `eslint` on changed files (`--max-warnings 0`) — pass
- `cspell` spelling + unused-words checks — pass
- `vitest run` for `@quests/ai-gateway` — 146/146 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)